### PR TITLE
feat(sandbox): SandboxSession API for domain-bound sandbox access

### DIFF
--- a/apps/web/lib/deployment/e2b-site-deployment.ts
+++ b/apps/web/lib/deployment/e2b-site-deployment.ts
@@ -1,34 +1,15 @@
-import { createSandboxSessionRegistry, SANDBOX_WORKSPACE_ROOT } from "@webalive/sandbox"
+import { SANDBOX_WORKSPACE_ROOT } from "@webalive/sandbox"
 import { assignPort } from "@webalive/site-controller"
 import type { Sandbox } from "e2b"
 import type { ResolvedDomain } from "@/lib/domain/resolve-domain-runtime"
-import { getE2bDomain } from "@/lib/env"
 import { prepareE2bScratchWorkspace } from "@/lib/sandbox/e2b-workspace"
+import { getSessionRegistry } from "@/lib/sandbox/session-registry"
 import { createAppClient } from "@/lib/supabase/app"
 
 export interface E2bSiteDeploymentResult {
   port: number
   serviceName: string
   scratchWorkspace: string
-}
-
-async function updateSandboxState(
-  domainId: string,
-  sandboxId: string,
-  status: import("@webalive/database").SandboxStatus,
-) {
-  const app = await createAppClient("service")
-  const { error } = await app
-    .from("domains")
-    .update({
-      sandbox_id: sandboxId.length > 0 ? sandboxId : null,
-      sandbox_status: status,
-    })
-    .eq("domain_id", domainId)
-
-  if (error) {
-    throw new Error(`Failed to persist sandbox state for ${domainId}: ${error.message}`)
-  }
 }
 
 async function ensureSandboxGitRepo(sandbox: Sandbox, hostname: string): Promise<void> {
@@ -85,14 +66,7 @@ export async function prepareE2bSiteDeployment(params: {
 }
 
 export async function createInitialSiteSandbox(domain: ResolvedDomain, scratchWorkspace: string): Promise<void> {
-  const registry = createSandboxSessionRegistry({
-    persistence: {
-      updateSandbox: updateSandboxState,
-    },
-    domain: getE2bDomain(),
-  })
-
-  const session = await registry.acquire(domain, scratchWorkspace)
+  const session = await getSessionRegistry().acquire(domain, scratchWorkspace)
   try {
     await ensureSandboxGitRepo(session.raw, domain.hostname)
   } catch (error) {

--- a/packages/sandbox/src/registry.test.ts
+++ b/packages/sandbox/src/registry.test.ts
@@ -95,6 +95,45 @@ describe("SandboxSessionRegistry", () => {
     expect(session2).not.toBe(session1)
   })
 
+  it("concurrent acquire calls return the same session (no duplicates)", async () => {
+    let resolveCreate: (value: unknown) => void
+    const sandbox = {
+      sandboxId: "sbx_dedup",
+      files: { list: vi.fn().mockResolvedValue([]) },
+      commands: { run: vi.fn() },
+      getHost: vi.fn(),
+    }
+    mockCreate.mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveCreate = resolve
+      }),
+    )
+
+    const registry = createRegistry()
+    const promise1 = registry.acquire(domain)
+    const promise2 = registry.acquire(domain)
+
+    resolveCreate!(sandbox)
+    const [session1, session2] = await Promise.all([promise1, promise2])
+
+    expect(session1).toBe(session2)
+    expect(mockCreate).toHaveBeenCalledTimes(1)
+  })
+
+  it("acquire propagates Sandbox.create errors", async () => {
+    mockCreate.mockRejectedValueOnce(new Error("E2B quota exceeded"))
+
+    const registry = createRegistry()
+    await expect(registry.acquire(domain)).rejects.toThrow("E2B quota exceeded")
+  })
+
+  it("acquire propagates persistence errors", async () => {
+    updateSandbox.mockRejectedValueOnce(new Error("DB write failed"))
+
+    const registry = createRegistry()
+    await expect(registry.acquire(domain)).rejects.toThrow("DB write failed")
+  })
+
   it("session.files provides path-validated access", async () => {
     const sandbox = {
       sandboxId: "sbx_scoped",

--- a/packages/sandbox/src/registry.ts
+++ b/packages/sandbox/src/registry.ts
@@ -51,6 +51,7 @@ export function createSandboxSessionRegistry(config: SandboxSessionRegistryConfi
   })
 
   const sessions = new Map<string, SandboxSession>()
+  const pending = new Map<string, Promise<SandboxSession>>()
 
   return {
     async acquire(domain: SandboxDomain, hostWorkspacePath?: string): Promise<SandboxSession> {
@@ -59,15 +60,33 @@ export function createSandboxSessionRegistry(config: SandboxSessionRegistryConfi
         return cached
       }
 
-      const sandbox = await manager.getOrCreate(domain, hostWorkspacePath)
-      const session = createSandboxSession({ domain_id: domain.domain_id, hostname: domain.hostname }, sandbox, manager)
+      const inflight = pending.get(domain.domain_id)
+      if (inflight) {
+        return inflight
+      }
 
-      sessions.set(domain.domain_id, session)
-      return session
+      const promise = manager.getOrCreate(domain, hostWorkspacePath).then(sandbox => {
+        const session = createSandboxSession(
+          { domain_id: domain.domain_id, hostname: domain.hostname },
+          sandbox,
+          manager,
+        )
+        sessions.set(domain.domain_id, session)
+        pending.delete(domain.domain_id)
+        return session
+      })
+
+      promise.catch(() => {
+        pending.delete(domain.domain_id)
+      })
+
+      pending.set(domain.domain_id, promise)
+      return promise
     },
 
     evict(domainId: string): void {
       sessions.delete(domainId)
+      pending.delete(domainId)
       manager.evict(domainId)
     },
   }

--- a/packages/sandbox/src/scoped-files.test.ts
+++ b/packages/sandbox/src/scoped-files.test.ts
@@ -101,6 +101,14 @@ describe("ScopedFilesystem", () => {
 
       await expect(scoped.list("../")).rejects.toThrow(RuntimePathValidationError)
     })
+
+    it("throws on absolute paths", async () => {
+      const sandbox = mockSandbox()
+      const scoped = createScopedFilesystem(sandbox as never)
+
+      await expect(scoped.list("/etc")).rejects.toThrow(RuntimePathValidationError)
+      expect(sandbox.files.list).not.toHaveBeenCalled()
+    })
   })
 
   describe("makeDir", () => {

--- a/packages/sandbox/src/session.ts
+++ b/packages/sandbox/src/session.ts
@@ -33,7 +33,10 @@ export interface SandboxCommandHandle {
 export interface SandboxSessionCommands {
   /**
    * Run a command. cwd defaults to SANDBOX_WORKSPACE_ROOT.
-   * background=true returns immediately with a handle — use for dev servers.
+   *
+   * When `background: true`, returns immediately with a synthetic `exitCode: 0`
+   * that does NOT reflect actual command completion — the process continues
+   * running in the sandbox. Use for long-lived processes like dev servers.
    */
   run(
     cmd: string,


### PR DESCRIPTION
## Summary

- Introduces `SandboxSession` + `SandboxSessionRegistry` in `@webalive/sandbox` — a domain-bound session object that owns the connected sandbox, enforces path security via `ScopedFilesystem`, and exposes E2B SDK method names (`read`/`write`/`list`/`makeDir`/`remove`)
- Migrates all 5 file API routes and `e2b-site-deployment.ts` from the old `ConnectedSandboxRuntime` + `e2b-file-runtime.ts` helpers to `registry.acquire(domain)` + `session.files.*`
- Net -42 lines changed (simpler, not bigger). 32 new tests (43 total in sandbox package)

### New package files
| File | Purpose |
|---|---|
| `scoped-files.ts` | `ScopedFilesystem` proxy over E2B SDK `files.*` with path validation |
| `session.ts` | `SandboxSession` binding domain + sandbox + commands + lifecycle |
| `registry.ts` | `SandboxSessionRegistry` factory with in-process session caching |

### Before/After

```typescript
// Before: domain on every call, manual path validation, adapter layer
const runtime = createConnectedSandboxRuntime(config)
const content = await runtime.readTextFile(toSandboxDomain(domain), filePath)

// After: acquire once, use SDK method names, security enforced
const session = await registry.acquire(domain)
const content = await session.files.read(filePath)
```

### What's NOT changed yet
- `createE2bMcp()` still takes raw `Sandbox` (MCP tools do their own path validation internally)
- `worker-entry.mjs` still uses `SandboxManager` directly (separate migration)
- Old `ConnectedSandboxRuntime` exports kept for backward compat (can be removed when worker migrates)

### Where this is going: before → after

**Before** (current state across the codebase):
```typescript
// File routes: runtime + manual domain threading
const runtime = createConnectedSandboxRuntime(config)
const content = await runtime.readTextFile(toSandboxDomain(domain), filePath)
await runtime.writeFile(toSandboxDomain(domain), filePath, body)
const entries = await runtime.listDirectory(toSandboxDomain(domain), dir)

// Deployment: raw SandboxManager, manual DB sync
const manager = new SandboxManager(config)
const sandbox = await manager.getOrCreate(domain, workspace)
await sandbox.commands.run("bun install", { cwd: SANDBOX_WORKSPACE_ROOT })
await updateSandboxState(domainId, sandbox.sandboxId, "running")  // manual

// MCP: raw Sandbox passed around
const sandbox = await manager.getOrCreate(domain)
const mcp = createE2bMcp(sandbox)  // does its own path validation

// Worker: yet another way in
const manager = new SandboxManager(config)
const sandbox = await manager.getOrCreate(domain, workspace)
```

**After** (when migration is complete):
```typescript
// Everything — files, commands, MCP, deployment, worker — one entry point
const session = await registry.acquire(domain)

session.files.read("src/app.ts")       // path security enforced
session.files.write("src/app.ts", code)
session.files.list("")
session.commands.run("bun install")    // cwd defaults to workspace root
session.mcp                            // MCP server bound to session
session.getHost(3000)                  // preview URL
session.pause()                        // DB sync automatic
session.kill()                         // DB sync automatic
```

**What gets deleted:** `ConnectedSandboxRuntime`, `runtime-facade.ts`, `e2b-file-runtime.ts`, every `toSandboxDomain()` call, every manual `updateSandboxState()` call, `SandboxManager` as a public API.

**What stays:** `SandboxSession` (one type to touch), `SandboxSessionRegistry` (one way to get it), `ScopedFilesystem` (path security on every op). If you have a session, you can't do anything unsafe.

## Test plan
- [x] 32 new unit tests for scoped-files, session, and registry
- [x] Updated file list route test to mock session registry
- [x] All 43 sandbox package tests pass
- [x] All 800+ web app tests pass
- [x] `bun run check:affected` passes (20/20 tasks)
- [x] Pre-push `static-check` passes
- [ ] Manual verification with E2B sandbox after deploy to staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a session-based registry and session APIs to centralize sandbox sessions and filesystem access.
* **Refactor**
  * Switched file operations (read, write, list, delete, upload) to use session-backed filesystem calls.
  * Introduced a scoped filesystem abstraction to enforce workspace path validation.
  * Removed special "sandbox not ready" response paths for several file operations.
* **Tests**
  * Added comprehensive tests for session registry, session behavior, and scoped filesystem.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

